### PR TITLE
feat(command): implement the command output

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,10 @@ linters:
     - unparam
     - gocyclo
     - goimports
+    - paralleltest
+  linters-settings:
+    paralleltest:
+      path: ./tools/paralleltest.go
   disable:
     - typecheck
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,9 +19,6 @@ linters:
     - gocyclo
     - goimports
     - paralleltest
-  linters-settings:
-    paralleltest:
-      path: ./tools/paralleltest.go
   disable:
     - typecheck
 
@@ -36,6 +33,8 @@ linters-settings:
       - name: package-comments
         severity: warning
         disabled: false
+  paralleltest:
+    path: ./tools/paralleltest.go
 
 issues:
   exclude-use-default: false

--- a/command/output/doc.go
+++ b/command/output/doc.go
@@ -1,0 +1,2 @@
+// Package output provides structures and functions to handle command output.
+package output

--- a/command/output/lines.go
+++ b/command/output/lines.go
@@ -46,14 +46,18 @@ func (l Lines) Last() string {
 
 // At returns the line at the specified index.
 //
-// It returns an empty string if the index is out of bounds.
+// If the index is out of bounds, it returns an empty string.
+//
+// The method supports negative indexing, where -1 refers to the last line,
+// -2 to the second last line, and so on.
+// For example, At(-1) returns the last line, At(-2) returns the second to last line, and so on.
 func (l Lines) At(idx int) string {
 	n := l.Len()
-	if n == 0 || idx >= n {
-		return ""
-	}
 	if idx < 0 {
 		idx = n + idx
+	}
+	if idx < 0 || idx >= n {
+		return ""
 	}
 	return l[idx]
 }

--- a/command/output/lines.go
+++ b/command/output/lines.go
@@ -46,10 +46,11 @@ func (l Lines) Last() string {
 
 // At returns the line at the specified index.
 //
-// If the index is out of bounds, it returns an empty string.
+// If idx is negative, it is interpreted as an offset from the end of the
+// slice (e.g., -1 refers to the last line, -2 to the second-to-last, etc.).
+// It returns an empty string if there are no lines or if the index is out of
+// bounds.
 //
-// The method supports negative indexing, where -1 refers to the last line,
-// -2 to the second last line, and so on.
 // For example, At(-1) returns the last line, At(-2) returns the second to last line, and so on.
 func (l Lines) At(idx int) string {
 	n := l.Len()

--- a/command/output/lines.go
+++ b/command/output/lines.go
@@ -1,0 +1,59 @@
+package output
+
+// Lines represents a collection of output lines from a command execution.
+//
+// It is essentially a slice of strings, where each string is a line of output.
+type Lines []string
+
+// NewLines creates and returns a new Lines instance
+// from the provided slice of strings.
+//
+// Parameters:
+//   - lines: A slice of strings representing the lines of output.
+func NewLines(lines []string) Lines {
+	return Lines(lines)
+}
+
+// Len returns the number of lines.
+func (l Lines) Len() int {
+	return len(l)
+}
+
+// Empty checks if there are no lines.
+func (l Lines) Empty() bool {
+	return l.Len() == 0
+}
+
+// First returns the first line.
+//
+// It returns an empty string if there are no lines.
+func (l Lines) First() string {
+	if l.Empty() {
+		return ""
+	}
+	return l[0]
+}
+
+// Last returns the last line.
+//
+// It returns an empty string if there are no lines.
+func (l Lines) Last() string {
+	if l.Empty() {
+		return ""
+	}
+	return l[l.Len()-1]
+}
+
+// At returns the line at the specified index.
+//
+// It returns an empty string if the index is out of bounds.
+func (l Lines) At(idx int) string {
+	n := l.Len()
+	if n == 0 || idx >= n {
+		return ""
+	}
+	if idx < 0 {
+		idx = n + idx
+	}
+	return l[idx]
+}

--- a/command/output/lines.go
+++ b/command/output/lines.go
@@ -50,8 +50,6 @@ func (l Lines) Last() string {
 // slice (e.g., -1 refers to the last line, -2 to the second-to-last, etc.).
 // It returns an empty string if there are no lines or if the index is out of
 // bounds.
-//
-// For example, At(-1) returns the last line, At(-2) returns the second to last line, and so on.
 func (l Lines) At(idx int) string {
 	n := l.Len()
 	if idx < 0 {

--- a/command/output/lines_test.go
+++ b/command/output/lines_test.go
@@ -204,6 +204,34 @@ func TestLines_At(t *testing.T) {
 			want: "line2",
 		},
 		{
+			name: "out of bound",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			idx: 3,
+		},
+		{
+			name: "negative out of bound",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			idx:  -3,
+			want: "line1",
+		},
+		{
+			name: "quite negative out of bound",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			idx: -4,
+		},
+		{
 			name:  "empty",
 			lines: []string{},
 		},

--- a/command/output/lines_test.go
+++ b/command/output/lines_test.go
@@ -213,7 +213,7 @@ func TestLines_At(t *testing.T) {
 			idx: 3,
 		},
 		{
-			name: "negative out of bound",
+			name: "negative index to first element",
 			lines: []string{
 				"line1",
 				"line2",
@@ -223,7 +223,7 @@ func TestLines_At(t *testing.T) {
 			want: "line1",
 		},
 		{
-			name: "quite negative out of bound",
+			name: "negative out of bound",
 			lines: []string{
 				"line1",
 				"line2",

--- a/command/output/lines_test.go
+++ b/command/output/lines_test.go
@@ -1,0 +1,222 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLines_Len(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		lines []string
+		want  int
+	}{
+		{
+			name: "ok",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			want: 3,
+		},
+		{
+			name:  "empty",
+			lines: []string{},
+		},
+		{
+			name: "nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewLines(tt.lines).Len()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLines_Empty(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		lines []string
+		want  bool
+	}{
+		{
+			name: "ok",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+		},
+		{
+			name:  "empty",
+			lines: []string{},
+			want:  true,
+		},
+		{
+			name: "nil",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewLines(tt.lines).Empty()
+			if tt.want {
+				assert.True(t, got)
+			} else {
+				assert.False(t, got)
+			}
+		})
+	}
+}
+
+func TestLines_First(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{
+			name: "ok",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			want: "line1",
+		},
+		{
+			name:  "empty",
+			lines: []string{},
+		},
+		{
+			name:  "nil",
+			lines: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewLines(tt.lines).First()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLines_Last(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{
+			name: "ok",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			want: "line3",
+		},
+		{
+			name:  "empty",
+			lines: []string{},
+		},
+		{
+			name:  "nil",
+			lines: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewLines(tt.lines).Last()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLines_At(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		lines []string
+		idx   int
+		want  string
+	}{
+		{
+			name: "index 0",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			idx:  0,
+			want: "line1",
+		},
+		{
+			name: "index 1",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			idx:  1,
+			want: "line2",
+		},
+		{
+			name: "index 2",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			idx:  2,
+			want: "line3",
+		},
+		{
+			name: "index -1",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			idx:  -1,
+			want: "line3",
+		},
+		{
+			name: "index -2",
+			lines: []string{
+				"line1",
+				"line2",
+				"line3",
+			},
+			idx:  -2,
+			want: "line2",
+		},
+		{
+			name:  "empty",
+			lines: []string{},
+		},
+		{
+			name:  "nil",
+			lines: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewLines(tt.lines).At(tt.idx)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/command/output/output.go
+++ b/command/output/output.go
@@ -1,0 +1,63 @@
+package output
+
+import "strings"
+
+// Output represents the output of a system command execution.
+type Output struct {
+	// stdout holds the standard output of the command.
+	stdout []byte
+}
+
+// NewOutput creates and returns a new Output instance
+// with the specified standard output.
+//
+// Parameters:
+//   - stdout: A byte slice representing the standard output of the command.
+func NewOutput(stdout []byte) Output {
+	return Output{
+		stdout: stdout,
+	}
+}
+
+// Len returns the length of the output.
+func (o Output) Len() int {
+	return len(o.stdout)
+}
+
+// Empty checks if the output is empty.
+func (o Output) Empty() bool {
+	return o.Len() == 0
+}
+
+// String returns a string representation of the output.
+func (o Output) String() string {
+	return string(o.stdout)
+}
+
+// Lines splits the output into lines and returns them as a Lines instance.
+//
+// It splits the output string at each newline character.
+func (o Output) Lines() Lines {
+	if o.Empty() {
+		return NewLines(nil)
+	}
+	return NewLines(
+		strings.Split(
+			o.String(),
+			"\n",
+		),
+	)
+}
+
+// Bytes returns the output as a byte slice.
+//
+// It returns a copy of the internal byte slice
+// to prevent external modification.
+func (o Output) Bytes() []byte {
+	if o.Empty() {
+		return nil
+	}
+	res := make([]byte, len(o.stdout))
+	copy(res, o.stdout)
+	return res
+}

--- a/command/output/output.go
+++ b/command/output/output.go
@@ -14,8 +14,13 @@ type Output struct {
 // Parameters:
 //   - stdout: A byte slice representing the standard output of the command.
 func NewOutput(stdout []byte) Output {
+	var out []byte
+	if len(stdout) > 0 {
+		out = make([]byte, len(stdout))
+		copy(out, stdout)
+	}
 	return Output{
-		stdout: stdout,
+		stdout: out,
 	}
 }
 

--- a/command/output/output_test.go
+++ b/command/output/output_test.go
@@ -137,15 +137,12 @@ func TestOutput_Lines(t *testing.T) {
 		want   Lines
 	}{
 		{
-			name: "with new lines",
-			stdout: []byte(`line1
-line2
-line3`),
-
+			name:   "with new lines",
+			stdout: []byte("line1\nline2\n"),
 			want: NewLines([]string{
 				"line1",
 				"line2",
-				"line3",
+				"",
 			}),
 		},
 		{

--- a/command/output/output_test.go
+++ b/command/output/output_test.go
@@ -1,0 +1,205 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOutput_Len(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		stdout []byte
+		want   int
+	}{
+		{
+			name: "with new lines",
+			stdout: []byte(`line1
+line2
+line3`),
+			want: 17,
+		},
+		{
+			name:   "chinese",
+			stdout: []byte("你好，世界"),
+			want:   15,
+		},
+		{
+			name:   "spaces",
+			stdout: []byte("     "),
+			want:   5,
+		},
+		{
+			name:   "empty",
+			stdout: []byte{},
+		},
+		{
+			name: "nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewOutput(tt.stdout).Len()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+func TestOutput_Empty(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		stdout []byte
+		want   bool
+	}{
+		{
+			name: "ok",
+			stdout: []byte(`line1
+line2
+line3`),
+		},
+		{
+			name:   "spaces",
+			stdout: []byte("     "),
+		},
+		{
+			name:   "empty",
+			stdout: []byte{},
+			want:   true,
+		},
+		{
+			name: "nil",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewOutput(tt.stdout).Empty()
+			if tt.want {
+				assert.True(t, got)
+			} else {
+				assert.False(t, got)
+			}
+		})
+	}
+}
+
+func TestOutput_String(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		stdout []byte
+		want   string
+	}{
+		{
+			name: "with new lines",
+			stdout: []byte(`line1
+line2
+line3`),
+			want: `line1
+line2
+line3`,
+		},
+		{
+			name:   "chinese",
+			stdout: []byte("你好，世界"),
+			want:   "你好，世界",
+		},
+		{
+			name:   "spaces",
+			stdout: []byte("     "),
+			want:   "     ",
+		},
+		{
+			name:   "empty",
+			stdout: []byte{},
+		},
+		{
+			name: "nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewOutput(tt.stdout).String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOutput_Lines(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		stdout []byte
+		want   Lines
+	}{
+		{
+			name: "with new lines",
+			stdout: []byte(`line1
+line2
+line3`),
+
+			want: NewLines([]string{
+				"line1",
+				"line2",
+				"line3",
+			}),
+		},
+		{
+			name:   "spaces",
+			stdout: []byte("     "),
+			want:   NewLines([]string{"     "}),
+		},
+		{
+			name:   "empty",
+			stdout: []byte{},
+			want:   NewLines(nil),
+		},
+		{
+			name: "nil",
+			want: NewLines(nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewOutput(tt.stdout).Lines()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOutput_Bytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		stdout []byte
+		want   []byte
+	}{
+		{
+			name:   "ok",
+			stdout: []byte(`foo`),
+			want:   []byte(`foo`),
+		},
+		{
+			name:   "empty",
+			stdout: []byte{},
+		},
+		{
+			name: "nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewOutput(tt.stdout).Bytes()
+			assert.Equal(t, tt.want, got)
+			if len(got) > 0 && len(tt.want) > 0 {
+				assert.False(t, &tt.stdout[0] == &got[0], "must be different slices")
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Added `Output{}` represents the command output based on stdout
- Added `Lines{}` represents this one as lines of strings
- Added `paralleltest` to linter configuration