### PR TITLE
feat: command execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,26 @@ check: test lint
 
 .PHONY: test
 test:
-	@go test ./... -race -count=1
+	@$(MAKE) unit-test || { \
+		echo "❌ Unit tests failed; skipping integration tests"; \
+		exit 1; \
+	}
+	@$(MAKE) integration-test
+
+.PHONY: unit-test
+unit-test:
+	@echo 🧪 Running unit tests...
+	@pkgs=$$(go list ./... | grep -v 'test/integration$$'); \
+	if [ -n "$$pkgs" ]; then \
+		go test $$pkgs; \
+	else \
+		echo "no packages to test"; \
+	fi
+
+.PHONY: integration-test
+integration-test:
+	@echo 🧪 Running integration tests...
+	@go test -tags=integration ./internal/test/integration/... -race -count=1
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ unit-test:
 	@echo 🧪 Running unit tests...
 	@pkgs=$$(go list ./... | grep -v './internal/test/integration$$'); \
 	if [ -n "$$pkgs" ]; then \
-		go test $$pkgs; \
+		go test -race -count=1 $$pkgs; \
 	else \
 		echo "no packages to test"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 .PHONY: unit-test
 unit-test:
 	@echo 🧪 Running unit tests...
-	@pkgs=$$(go list ./... | grep -v 'test/integration$$'); \
+	@pkgs=$$(go list ./... | grep -v './internal/test/integration$$'); \
 	if [ -n "$$pkgs" ]; then \
 		go test $$pkgs; \
 	else \

--- a/command/command.go
+++ b/command/command.go
@@ -1,6 +1,8 @@
 package command
 
-import "strings"
+import (
+	"strings"
+)
 
 // Command represents a system command with its name and arguments.
 type Command struct {
@@ -19,8 +21,13 @@ func NewCommand(
 	name string,
 	args ...string,
 ) Command {
+	var aa []string
+	if len(args) > 0 {
+		aa = make([]string, len(args))
+		copy(aa, args)
+	}
 	return Command{
-		args: args,
+		args: aa,
 		name: name,
 	}
 }
@@ -35,4 +42,19 @@ func (c Command) String() string {
 		return c.name
 	}
 	return c.name + " " + strings.Join(c.args, " ")
+}
+
+// Name returns the name of the Command.
+func (c Command) Name() string {
+	return c.name
+}
+
+// Args returns a copy of the arguments slice of the Command.
+func (c Command) Args() []string {
+	if len(c.args) == 0 {
+		return nil
+	}
+	res := make([]string, len(c.args))
+	copy(res, c.args)
+	return res
 }

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -86,3 +86,90 @@ func TestString(t *testing.T) {
 		assert.Empty(t, got)
 	})
 }
+
+func TestCommand_Name(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		args []string
+		name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "with name",
+			fields: fields{
+				name: "docker run",
+				args: []string{"container_id", "--force"},
+			},
+			want: "docker run",
+		},
+		{
+			name: "empty name",
+			fields: fields{
+				args: []string{"container_id", "--force"},
+			},
+		},
+		{
+			name: "zero value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewCommand(
+				tt.fields.name,
+				tt.fields.args...,
+			).Name()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCommand_Args(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		args []string
+		name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			name: "with args",
+			fields: fields{
+				name: "docker run",
+				args: []string{"container_id", "--force"},
+			},
+			want: []string{"container_id", "--force"},
+		},
+		{
+			name: "empty args",
+			fields: fields{
+				name: "docker run",
+				args: []string{},
+			},
+		},
+		{
+			name: "zero value",
+			fields: fields{
+				name: "",
+				args: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NewCommand(
+				tt.fields.name,
+				tt.fields.args...,
+			).Args()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/test/fake/doc.go
+++ b/internal/test/fake/doc.go
@@ -1,0 +1,2 @@
+// Package fake provides fake implementations for testing purposes.
+package fake

--- a/internal/test/fake/errors.go
+++ b/internal/test/fake/errors.go
@@ -1,0 +1,8 @@
+package fake
+
+import "errors"
+
+var (
+	// Err is a fake error for testing purposes.
+	Err = errors.New("fake error")
+)

--- a/internal/test/fake/shell/doc.go
+++ b/internal/test/fake/shell/doc.go
@@ -1,0 +1,2 @@
+// Package shell provides fake implementations of shell-related interfaces for testing purposes.
+package shell

--- a/internal/test/fake/shell/shell.go
+++ b/internal/test/fake/shell/shell.go
@@ -1,0 +1,59 @@
+package shell
+
+import (
+	"context"
+
+	"github.com/sitnikovik/osxec/command"
+	proc "github.com/sitnikovik/osxec/process/execution"
+)
+
+// Shell is a fake implementation of the Shell interface for testing purposes.
+type Shell struct {
+	// resp holds predefined responses for specific commands.
+	resp map[string]proc.Execution
+}
+
+// Option defines a function type for configuring the Shell instance.
+type Option func(*Shell)
+
+// WithResponse sets a predefined response for a specific command.
+//
+// Parameters:
+//   - cmd: The command for which the response is to be set.
+//   - res: The execution result to be returned when the command is executed.
+func WithResponse(
+	cmd command.Command,
+	res proc.Execution,
+) Option {
+	return func(s *Shell) {
+		s.resp[cmd.String()] = res
+	}
+}
+
+// NewShell creates and returns a new Shell instance to execute system commands.
+func NewShell(opts ...Option) *Shell {
+	sh := &Shell{
+		resp: make(map[string]proc.Execution),
+	}
+	for _, opt := range opts {
+		opt(sh)
+	}
+	return sh
+}
+
+// Execution executes the given command and returns its execution result.
+//
+// If context is done before execution, it returns an error execution with context error.
+//
+// Parameters:
+//   - ctx: The context for managing the command execution lifecycle.
+//   - cmd: The command to be executed.
+func (s Shell) Execution(
+	ctx context.Context,
+	cmd command.Command,
+) proc.Execution {
+	if res, ok := s.resp[cmd.String()]; ok {
+		return res
+	}
+	panic("response not found for command '" + cmd.String() + "'")
+}

--- a/internal/test/fake/shell/shell.go
+++ b/internal/test/fake/shell/shell.go
@@ -42,13 +42,7 @@ func NewShell(opts ...Option) *Shell {
 }
 
 // Execution executes the given command and returns its execution result.
-//
-// If context is done before execution, it returns an error execution with context error.
-//
-// Parameters:
-//   - ctx: The context for managing the command execution lifecycle.
-//   - cmd: The command to be executed.
-func (s Shell) Execution(
+func (s *Shell) Execution(
 	ctx context.Context,
 	cmd command.Command,
 ) proc.Execution {

--- a/internal/test/integration/process/execution_test.go
+++ b/internal/test/integration/process/execution_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-package shell
+package process_test
 
 import (
 	"context"
@@ -28,7 +28,7 @@ func TestExecution(t *testing.T) {
 			).
 			Execution(ctx)
 		require.NoError(t, res.Err())
-		assert.Equal(t, res.String(), "Hello, World!\n")
+		assert.Equal(t, "Hello, World!\n", res.String())
 	})
 	t.Run("wrong command", func(t *testing.T) {
 		t.Parallel()

--- a/internal/test/integration/process/execution_test.go
+++ b/internal/test/integration/process/execution_test.go
@@ -51,10 +51,9 @@ func TestExecution(t *testing.T) {
 		res := process.
 			NewProcess(
 				shell.NewShell(),
-				command.NewCommand("sleep", "3"),
+				command.NewCommand("sleep", "2"),
 			).
 			Execution(ctx)
-		time.Sleep(2 * time.Second)
 		err := res.Err()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "signal: killed")

--- a/internal/test/integration/process/execution_test.go
+++ b/internal/test/integration/process/execution_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+// +build integration
+
+package shell
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sitnikovik/osxec/command"
+	"github.com/sitnikovik/osxec/process"
+	"github.com/sitnikovik/osxec/shell"
+)
+
+func TestExecution(t *testing.T) {
+	t.Parallel()
+	t.Run("echo hello world", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		res := process.
+			NewProcess(
+				shell.NewShell(),
+				command.NewCommand("echo", "Hello, World!"),
+			).
+			Execution(ctx)
+		require.NoError(t, res.Err())
+		assert.Equal(t, res.String(), "Hello, World!\n")
+	})
+	t.Run("wrong command", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		res := process.
+			NewProcess(
+				shell.NewShell(),
+				command.NewCommand("git", "sdasd"),
+			).
+			Execution(ctx)
+		assert.Error(t, res.Err())
+	})
+	t.Run("context done", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			1*time.Second,
+		)
+		defer cancel()
+		res := process.
+			NewProcess(
+				shell.NewShell(),
+				command.NewCommand("sleep", "3"),
+			).
+			Execution(ctx)
+		time.Sleep(2 * time.Second)
+		err := res.Err()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signal: killed")
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+	t.Run("context canceled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(
+			context.Background(),
+		)
+		cancel()
+		res := process.
+			NewProcess(
+				shell.NewShell(),
+				command.NewCommand("echo", "Hello"),
+			).
+			Execution(ctx)
+		err := res.Err()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+	t.Run("exit 128", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(
+			context.Background(),
+			1*time.Second,
+		)
+		defer cancel()
+		res := process.NewProcess(
+			shell.NewShell(),
+			command.NewCommand("sh", "-c", "exit 128"),
+		).Execution(ctx)
+		require.Error(t, res.Err())
+		assert.Equal(t, 128, res.Code().Int())
+	})
+}

--- a/internal/test/integration/process/exit_codes_test.go
+++ b/internal/test/integration/process/exit_codes_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+// +build integration
+
+package shell
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sitnikovik/osxec/command"
+	"github.com/sitnikovik/osxec/process"
+	"github.com/sitnikovik/osxec/shell"
+)
+
+func TestExitCodes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		cmd     command.Command
+		code    int
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			cmd:     command.NewCommand("sh", "-c", "exit 0"),
+			code:    0,
+			wantErr: false,
+		},
+		{
+			name:    "failure",
+			cmd:     command.NewCommand("sh", "-c", "exit 1"),
+			code:    1,
+			wantErr: true,
+		},
+		{
+			name:    "misuse",
+			cmd:     command.NewCommand("sh", "-c", "exit 2"),
+			code:    2,
+			wantErr: true,
+		},
+		{
+			name:    "not executed",
+			cmd:     command.NewCommand("sh", "-c", "exit 126"),
+			code:    126,
+			wantErr: true,
+		},
+		{
+			name:    "not found",
+			cmd:     command.NewCommand("sh", "-c", "exit 127"),
+			code:    127,
+			wantErr: true,
+		},
+		{
+			name:    "invalid argument",
+			cmd:     command.NewCommand("sh", "-c", "exit 128"),
+			code:    128,
+			wantErr: true,
+		},
+		{
+			name:    "terminated",
+			cmd:     command.NewCommand("sh", "-c", "exit 130"),
+			code:    130,
+			wantErr: true,
+		},
+		{
+			name:    "custom 45",
+			cmd:     command.NewCommand("sh", "-c", "exit 45"),
+			code:    45,
+			wantErr: true,
+		},
+		{
+			name:    "custom 255",
+			cmd:     command.NewCommand("sh", "-c", "exit 255"),
+			code:    255,
+			wantErr: true,
+		},
+		{
+			name:    "custom -123",
+			cmd:     command.NewCommand("sh", "-c", "exit -123"),
+			code:    133,
+			wantErr: true,
+		},
+		{
+			name:    "custom -123123",
+			cmd:     command.NewCommand("sh", "-c", "exit -123123"),
+			code:    13,
+			wantErr: true,
+		},
+		{
+			name:    "custom text",
+			cmd:     command.NewCommand("sh", "-c", "exit 'asdasd'"),
+			code:    255,
+			wantErr: true,
+		},
+		{
+			name:    "big num",
+			cmd:     command.NewCommand("sh", "-c", "exit 99999"),
+			code:    159,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				1*time.Second,
+			)
+			defer cancel()
+			res := process.
+				NewProcess(
+					shell.NewShell(),
+					tt.cmd,
+				).
+				Execution(ctx)
+			if tt.wantErr {
+				require.Error(t, res.Err())
+				assert.False(t, res.Code().Succeeded())
+			} else {
+				require.NoError(t, res.Err())
+				assert.True(t, res.Code().Succeeded())
+			}
+			assert.Equal(t, tt.code, res.Code().Int())
+		})
+	}
+}

--- a/internal/test/integration/process/exit_codes_test.go
+++ b/internal/test/integration/process/exit_codes_test.go
@@ -78,12 +78,6 @@ func TestExitCodes(t *testing.T) {
 			code:    255,
 			wantErr: true,
 		},
-		{
-			name:    "custom -123",
-			cmd:     command.NewCommand("sh", "-c", "exit -123"),
-			code:    133,
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/test/integration/process/exit_codes_test.go
+++ b/internal/test/integration/process/exit_codes_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-package shell
+package process_test
 
 import (
 	"context"

--- a/internal/test/integration/process/exit_codes_test.go
+++ b/internal/test/integration/process/exit_codes_test.go
@@ -84,24 +84,6 @@ func TestExitCodes(t *testing.T) {
 			code:    133,
 			wantErr: true,
 		},
-		{
-			name:    "custom -123123",
-			cmd:     command.NewCommand("sh", "-c", "exit -123123"),
-			code:    13,
-			wantErr: true,
-		},
-		{
-			name:    "custom text",
-			cmd:     command.NewCommand("sh", "-c", "exit 'asdasd'"),
-			code:    255,
-			wantErr: true,
-		},
-		{
-			name:    "big num",
-			cmd:     command.NewCommand("sh", "-c", "exit 99999"),
-			code:    159,
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/process/doc.go
+++ b/process/doc.go
@@ -1,0 +1,2 @@
+// Package process provides types and functions for managing system processes.
+package process

--- a/process/execution/doc.go
+++ b/process/execution/doc.go
@@ -1,0 +1,2 @@
+// Package execution provides types and functions for handling process execution results.
+package execution

--- a/process/execution/execution.go
+++ b/process/execution/execution.go
@@ -1,0 +1,75 @@
+package execution
+
+import (
+	"strings"
+
+	"github.com/sitnikovik/osxec/command/output"
+	"github.com/sitnikovik/osxec/process/exit/code"
+)
+
+// Execution represents the result of executing a process.
+type Execution struct {
+	// bb is the byte slice output of the execution.
+	bb []byte
+	// err is the error that occurred during execution.
+	err error
+}
+
+// NewExecution creates a new Execution instance with the provided output bytes and error.
+//
+// Parameters:
+//   - bb: A byte slice representing the output of the execution.
+//   - err: An error representing any error that occurred during execution.
+func NewExecution(
+	bb []byte,
+	err error,
+) Execution {
+	var bc []byte
+	if len(bb) > 0 {
+		bc = make([]byte, len(bb))
+		copy(bc, bb)
+	}
+	return Execution{
+		bb:  bc,
+		err: err,
+	}
+}
+
+// String returns the string representation of the execution output.
+func (e Execution) String() string {
+	return e.Output().String()
+}
+
+// Err returns the error that occurred during execution.
+func (e Execution) Err() error {
+	return e.err
+}
+
+// Output returns the output of the execution as an Output instance.
+func (e Execution) Output() output.Output {
+	return output.NewOutput(e.bb)
+}
+
+// Code returns the exit code of the execution.
+func (e Execution) Code() code.Code {
+	if !e.Failed() {
+		return code.Success
+	}
+	splitted := strings.Split(
+		e.err.Error(),
+		"exit status ",
+	)
+	if len(splitted) == 2 {
+		c, err := code.ParseCode(splitted[1])
+		if err != nil {
+			return code.Failure
+		}
+		return c
+	}
+	return code.Failure
+}
+
+// Failed indicates whether the execution failed based on the presence of an error.
+func (e Execution) Failed() bool {
+	return e.err != nil
+}

--- a/process/execution/execution_test.go
+++ b/process/execution/execution_test.go
@@ -1,0 +1,189 @@
+package execution_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sitnikovik/osxec/command/output"
+	"github.com/sitnikovik/osxec/internal/test/fake"
+	exec "github.com/sitnikovik/osxec/process/execution"
+	"github.com/sitnikovik/osxec/process/exit/code"
+)
+
+func TestExecution_Code(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		bb  []byte
+		err error
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   code.Code
+	}{
+		{
+			name: "ok 0",
+			fields: fields{
+				bb: []byte("foo"),
+			},
+			want: code.Success,
+		},
+		{
+			name: "code 1 from error",
+			fields: fields{
+				err: errors.New("exit status 1"),
+			},
+			want: code.Failure,
+		},
+		{
+			name: "code not found in error",
+			fields: fields{
+				err: fake.Err,
+			},
+			want: code.Failure,
+		},
+		{
+			name: "code not parsed in error",
+			fields: fields{
+				err: errors.New("exit status foo"),
+			},
+			want: code.Failure,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := exec.
+				NewExecution(
+					tt.fields.bb,
+					tt.fields.err,
+				).
+				Code()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExecution_Output(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		bb  []byte
+		err error
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   output.Output
+	}{
+		{
+			name: "ok",
+			fields: fields{
+				bb: []byte("foo"),
+			},
+			want: output.NewOutput([]byte("foo")),
+		},
+		{
+			name: "empty",
+			fields: fields{
+				bb: []byte(""),
+			},
+			want: output.NewOutput([]byte("")),
+		},
+		{
+			name: "nil",
+			want: output.NewOutput(nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := exec.
+				NewExecution(
+					tt.fields.bb,
+					tt.fields.err,
+				).
+				Output()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExecution_Err(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		bb  []byte
+		err error
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr error
+	}{
+		{
+			name: "ok",
+			fields: fields{
+				err: fake.Err,
+			},
+			wantErr: fake.Err,
+		},
+		{
+			name: "nil err",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := exec.
+				NewExecution(
+					tt.fields.bb,
+					tt.fields.err,
+				).
+				Err()
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestExecution_String(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		bb  []byte
+		err error
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "ok",
+			fields: fields{
+				bb: []byte("foo"),
+			},
+			want: "foo",
+		},
+		{
+			name: "empty",
+			fields: fields{
+				bb: []byte(""),
+			},
+		},
+		{
+			name: "nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := exec.
+				NewExecution(
+					tt.fields.bb,
+					tt.fields.err,
+				).
+				String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/process/exit/code/code.go
+++ b/process/exit/code/code.go
@@ -1,0 +1,86 @@
+package code
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+var (
+	// ErrNotParsable is returned when an exit code cannot be parsed.
+	ErrNotParsable = errors.New("exit code is not parsable")
+	// ErrUnsupportedType is returned when an unsupported type is provided for exit code parsing.
+	ErrUnsupportedType = errors.New("unsupported type for exit code")
+)
+
+// Code represents the exit code of a process.
+type Code int16
+
+const (
+	// Unknown represents an unknown exit code.
+	//
+	// This exit code is used when the actual exit code cannot be determined or parsed.
+	Unknown Code = -1
+	// Success indicates that the process completed successfully.
+	//
+	// This exit code is commonly used to indicate that a program has
+	// executed without any errors.
+	Success Code = 0
+	// Failure indicates that the process failed.
+	//
+	// This exit code is commonly used to indicate a general error or failure
+	// that does not fall under more specific categories.
+	Failure Code = 1
+)
+
+// ParseCode parses the provided code value and returns it.
+//
+// The code parameter can be of type uint8, int, or string.
+// It converts the provided value to a Code type accordingly.
+// If the conversion fails, it returns an error.
+func ParseCode[T uint8 | int | string](code T) (Code, error) {
+	switch v := any(code).(type) {
+	case uint8:
+		return Code(v), nil
+	case int:
+		if v < 0 || v > 255 {
+			return Unknown, fmt.Errorf(
+				"%w from '%d': value out of range [0-255]",
+				ErrNotParsable,
+				v,
+			)
+		}
+		return Code(v), nil
+	case string:
+		n, err := strconv.ParseUint(v, 10, 8)
+		if err != nil {
+			return Unknown, fmt.Errorf(
+				"%w from '%s': %v",
+				ErrNotParsable,
+				v,
+				err,
+			)
+		}
+		return Code(uint8(n)), nil
+	default:
+		return Unknown, ErrUnsupportedType
+	}
+}
+
+// Int returns the integer representation of the Code.
+func (c Code) Int() int {
+	return int(c)
+}
+
+// Succeeded indicates whether the Code represents a success.
+func (c Code) Succeeded() bool {
+	return c.Equals(Success)
+}
+
+// Equals compares numeric exit code values by their numeric values.
+//
+// This ensures that parsed/constructed Codes with the same numeric value
+// are considered equal even if they were produced differently.
+func (c Code) Equals(cmp Code) bool {
+	return c.Int() == cmp.Int()
+}

--- a/process/exit/code/code.go
+++ b/process/exit/code/code.go
@@ -14,13 +14,9 @@ var (
 )
 
 // Code represents the exit code of a process.
-type Code int16
+type Code uint8
 
 const (
-	// Unknown represents an unknown exit code.
-	//
-	// This exit code is used when the actual exit code cannot be determined or parsed.
-	Unknown Code = -1
 	// Success indicates that the process completed successfully.
 	//
 	// This exit code is commonly used to indicate that a program has
@@ -37,14 +33,15 @@ const (
 //
 // The code parameter can be of type uint8, int, or string.
 // It converts the provided value to a Code type accordingly.
-// If the conversion fails, it returns an error.
+//
+// If the conversion fails, it returns an error and Failure code.
 func ParseCode[T uint8 | int | string](code T) (Code, error) {
 	switch v := any(code).(type) {
 	case uint8:
 		return Code(v), nil
 	case int:
 		if v < 0 || v > 255 {
-			return Unknown, fmt.Errorf(
+			return Failure, fmt.Errorf(
 				"%w from '%d': value out of range [0-255]",
 				ErrNotParsable,
 				v,
@@ -54,7 +51,7 @@ func ParseCode[T uint8 | int | string](code T) (Code, error) {
 	case string:
 		n, err := strconv.ParseUint(v, 10, 8)
 		if err != nil {
-			return Unknown, fmt.Errorf(
+			return Failure, fmt.Errorf(
 				"%w from '%s': %v",
 				ErrNotParsable,
 				v,
@@ -63,7 +60,7 @@ func ParseCode[T uint8 | int | string](code T) (Code, error) {
 		}
 		return Code(uint8(n)), nil
 	default:
-		return Unknown, ErrUnsupportedType
+		return Failure, ErrUnsupportedType
 	}
 }
 

--- a/process/exit/code/code_test.go
+++ b/process/exit/code/code_test.go
@@ -1,0 +1,160 @@
+package code_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sitnikovik/osxec/process/exit/code"
+)
+
+func TestParseCodess(t *testing.T) {
+	t.Parallel()
+	t.Run("valid uint8", func(t *testing.T) {
+		t.Parallel()
+		var n uint8 = 5
+		got, err := code.ParseCode(n)
+		assert.NoError(t, err)
+		assert.Equal(t, code.Code(n), got)
+	})
+	t.Run("valid int", func(t *testing.T) {
+		t.Parallel()
+		var n int = 10
+		got, err := code.ParseCode(n)
+		assert.NoError(t, err)
+		assert.Equal(t, code.Code(n), got)
+	})
+	t.Run("out of range int", func(t *testing.T) {
+		t.Parallel()
+		var n int = 256
+		got, err := code.ParseCode(n)
+		assert.ErrorIs(t, err, code.ErrNotParsable)
+		assert.Equal(t, code.Unknown, got)
+	})
+	t.Run("out of range negative int", func(t *testing.T) {
+		t.Parallel()
+		var n int = -1
+		got, err := code.ParseCode(n)
+		assert.ErrorIs(t, err, code.ErrNotParsable)
+		assert.Equal(t, code.Unknown, got)
+	})
+	t.Run("valid string", func(t *testing.T) {
+		t.Parallel()
+		var s string = "15"
+		got, err := code.ParseCode(s)
+		assert.NoError(t, err)
+		assert.Equal(t, code.Code(15), got)
+	})
+	t.Run("word", func(t *testing.T) {
+		t.Parallel()
+		got, err := code.ParseCode("foo")
+		assert.Equal(t, code.Unknown, got)
+		assert.ErrorIs(t, err, code.ErrNotParsable)
+	})
+	t.Run("out of range string", func(t *testing.T) {
+		t.Parallel()
+		got, err := code.ParseCode("300")
+		assert.Equal(t, code.Unknown, got)
+		assert.ErrorIs(t, err, code.ErrNotParsable)
+	})
+	t.Run("out of range negative string", func(t *testing.T) {
+		t.Parallel()
+		got, err := code.ParseCode("-13")
+		assert.Equal(t, code.Unknown, got)
+		assert.ErrorIs(t, err, code.ErrNotParsable)
+	})
+}
+
+func TestCode_Int(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    code.Code
+		want int
+	}{
+		{
+			name: "success",
+			c:    code.Success,
+			want: 0,
+		},
+		{
+			name: "failure",
+			c:    code.Failure,
+			want: 1,
+		},
+		{
+			name: "custom 128",
+			c:    code.Code(128),
+			want: 128,
+		},
+		{
+			name: "custom 1",
+			c:    code.Code(1),
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.c.Int()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCode_Succeeded(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    code.Code
+		want bool
+	}{
+		{
+			name: "success",
+			c:    code.Success,
+			want: true,
+		},
+		{
+			name: "failure",
+			c:    code.Failure,
+			want: false,
+		},
+		{
+			name: "custom 128",
+			c:    code.Code(128),
+			want: false,
+		},
+		{
+			name: "custom 1",
+			c:    code.Code(1),
+			want: false,
+		},
+		{
+			name: "custom zero",
+			c:    code.Code(0),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.c.Succeeded()
+			if tt.want {
+				assert.True(t, got)
+			} else {
+				assert.False(t, got)
+			}
+		})
+	}
+}
+
+func TestCode_Equals(t *testing.T) {
+	t.Parallel()
+	t.Run("1 from string eq invalid argument code", func(t *testing.T) {
+		t.Parallel()
+		c, err := code.ParseCode("1")
+		require.NoError(t, err)
+		assert.True(t, c.Equals(code.Failure))
+	})
+}

--- a/process/exit/code/code_test.go
+++ b/process/exit/code/code_test.go
@@ -30,14 +30,14 @@ func TestParseCodess(t *testing.T) {
 		var n int = 256
 		got, err := code.ParseCode(n)
 		assert.ErrorIs(t, err, code.ErrNotParsable)
-		assert.Equal(t, code.Unknown, got)
+		assert.Equal(t, code.Failure, got)
 	})
 	t.Run("out of range negative int", func(t *testing.T) {
 		t.Parallel()
 		var n int = -1
 		got, err := code.ParseCode(n)
 		assert.ErrorIs(t, err, code.ErrNotParsable)
-		assert.Equal(t, code.Unknown, got)
+		assert.Equal(t, code.Failure, got)
 	})
 	t.Run("valid string", func(t *testing.T) {
 		t.Parallel()
@@ -49,19 +49,19 @@ func TestParseCodess(t *testing.T) {
 	t.Run("word", func(t *testing.T) {
 		t.Parallel()
 		got, err := code.ParseCode("foo")
-		assert.Equal(t, code.Unknown, got)
+		assert.Equal(t, code.Failure, got)
 		assert.ErrorIs(t, err, code.ErrNotParsable)
 	})
 	t.Run("out of range string", func(t *testing.T) {
 		t.Parallel()
 		got, err := code.ParseCode("300")
-		assert.Equal(t, code.Unknown, got)
+		assert.Equal(t, code.Failure, got)
 		assert.ErrorIs(t, err, code.ErrNotParsable)
 	})
 	t.Run("out of range negative string", func(t *testing.T) {
 		t.Parallel()
 		got, err := code.ParseCode("-13")
-		assert.Equal(t, code.Unknown, got)
+		assert.Equal(t, code.Failure, got)
 		assert.ErrorIs(t, err, code.ErrNotParsable)
 	})
 }

--- a/process/exit/code/doc.go
+++ b/process/exit/code/doc.go
@@ -1,0 +1,2 @@
+// Package code provides types and functions for handling process exit codes.
+package code

--- a/process/process.go
+++ b/process/process.go
@@ -1,0 +1,50 @@
+package process
+
+import (
+	"context"
+
+	"github.com/sitnikovik/osxec/command"
+	exec "github.com/sitnikovik/osxec/process/execution"
+)
+
+// Shell defines an interface for executing commands in a shell environment.
+type Shell interface {
+	// Execution executes the given command and returns its execution result.
+	//
+	// Parameters:
+	//   - ctx: The context for managing the command execution lifecycle.
+	//   - cmd: The command to be executed.
+	Execution(
+		ctx context.Context,
+		cmd command.Command,
+	) exec.Execution
+}
+
+// Process represents a system process that can execute commands using a shell.
+type Process struct {
+	// shell is the shell environment used to execute commands.
+	shell Shell
+	// cmd is the command to be executed by the process.
+	cmd command.Command
+}
+
+// NewProcess creates and returns a new Process instance with the specified shell and command.
+//
+// Parameters:
+//   - shell: The shell environment used to execute commands.
+//   - cmd: The command to be executed by the process.
+func NewProcess(
+	shell Shell,
+	cmd command.Command,
+) Process {
+	return Process{
+		shell: shell,
+		cmd:   cmd,
+	}
+}
+
+// Execution returns the execution result of the process
+// by executing its command in the specified shell.
+func (p Process) Execution(ctx context.Context) exec.Execution {
+	return p.shell.Execution(ctx, p.cmd)
+}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -1,0 +1,82 @@
+package process_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sitnikovik/osxec/command"
+	fakeShell "github.com/sitnikovik/osxec/internal/test/fake/shell"
+	"github.com/sitnikovik/osxec/process"
+	exec "github.com/sitnikovik/osxec/process/execution"
+)
+
+func TestProcess_Execution(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		shell process.Shell
+		cmd   command.Command
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   exec.Execution
+	}{
+		{
+			name: "ok",
+			fields: fields{
+				shell: fakeShell.NewShell(
+					fakeShell.WithResponse(
+						command.NewCommand("ping"),
+						exec.NewExecution([]byte("pong\n"), nil),
+					),
+				),
+				cmd: command.NewCommand("ping"),
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: exec.NewExecution([]byte("pong\n"), nil),
+		},
+		{
+			name: "command error",
+			fields: fields{
+				shell: fakeShell.NewShell(
+					fakeShell.WithResponse(
+						command.NewCommand("docker", "asdsaofjdk"),
+						exec.NewExecution(
+							[]byte("docker: 'asdsaofjdk' is not a docker command.\n"),
+							errors.New("exit status 1"),
+						),
+					),
+				),
+				cmd: command.NewCommand("docker", "asdsaofjdk"),
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			want: exec.NewExecution(
+				[]byte("docker: 'asdsaofjdk' is not a docker command.\n"),
+				errors.New("exit status 1"),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := process.
+				NewProcess(
+					tt.fields.shell,
+					tt.fields.cmd,
+				).
+				Execution(tt.args.ctx)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/shell/doc.go
+++ b/shell/doc.go
@@ -1,0 +1,2 @@
+// Package shell provides utilities for working with shell commands and scripts.
+package shell

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os/exec"
 
@@ -36,7 +35,7 @@ func (s Shell) Execution(
 			cmd.Args()...,
 		).
 		CombinedOutput()
-	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+	if err != nil && ctx.Err() == context.DeadlineExceeded {
 		err = fmt.Errorf("%w: %w", ctx.Err(), err)
 	}
 	return proc.NewExecution(bb, err)

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -1,0 +1,43 @@
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/sitnikovik/osxec/command"
+	proc "github.com/sitnikovik/osxec/process/execution"
+)
+
+// Shell provides an implementation for executing system commands.
+type Shell struct{}
+
+// NewShell creates and returns a new Shell instance to execute system commands.
+func NewShell() Shell {
+	return Shell{}
+}
+
+// Execution executes the given command and returns its execution result.
+//
+// If context is done before execution, it returns an error execution with context error.
+//
+// Parameters:
+//   - ctx: The context for managing the command execution lifecycle.
+//   - cmd: The command to be executed.
+func (s Shell) Execution(
+	ctx context.Context,
+	cmd command.Command,
+) proc.Execution {
+	bb, err := exec.
+		CommandContext(
+			ctx,
+			cmd.Name(),
+			cmd.Args()...,
+		).
+		CombinedOutput()
+	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		err = fmt.Errorf("%w: %w", ctx.Err(), err)
+	}
+	return proc.NewExecution(bb, err)
+}


### PR DESCRIPTION
This pull request introduces a new `process/execution` package for handling process execution results, adds a robust exit code abstraction, and improves testability and documentation throughout the codebase. The most significant changes include the introduction of the `Execution` type, a new `Code` type for exit codes, comprehensive tests, and enhancements to the `command` package. Additionally, new fake and integration test helpers are provided to support testing.

**Process execution and exit code abstraction:**

* Added the `process/execution` package with the `Execution` type to encapsulate process results, including output, error, and exit code parsing. (`process/execution/execution.go`, `process/execution/doc.go`) [[1]](diffhunk://#diff-94d8fcfff5e4896772833ae8458590700ca15edf8b5f34011262c7d6e445df7cR1-R75) [[2]](diffhunk://#diff-cb9fd97cb9f44d3a0ea94681f8e589a566370df38e4a90aa78d085818163f47bR1-R2)
* Introduced the `process/exit/code` package, providing a `Code` type for exit codes, parsing logic, and utility methods (`ParseCode`, `Succeeded`, `Equals`). (`process/exit/code/code.go`, `process/exit/code/code_test.go`, `process/exit/code/doc.go`) [[1]](diffhunk://#diff-9b2c9b6fba20b0938a265b04d545b7d6c0ad40cb4d3689ce9b4a97261e31b31eR1-R86) [[2]](diffhunk://#diff-fe0e4d5f66b5ad8378c63ceb2dfebec7a48c1495a6a51f1a5550f5276a3df7f4R1-R160)

**Testing improvements:**

* Added comprehensive unit tests for the new `Execution` and `Code` types, covering output, error, and code parsing logic. (`process/execution/execution_test.go`, `process/exit/code/code_test.go`) [[1]](diffhunk://#diff-405a7c3688d2a03220731ca1e7328d60bdbfde7db83ced1904498e0bcc8dc273R1-R189) [[2]](diffhunk://#diff-fe0e4d5f66b5ad8378c63ceb2dfebec7a48c1495a6a51f1a5550f5276a3df7f4R1-R160)
* Added integration tests for process execution and exit codes, including various scenarios (success, failure, context cancellation, exit codes). (`internal/test/integration/process/execution_test.go`, `internal/test/integration/process/exit_codes_test.go`) [[1]](diffhunk://#diff-5e5bba94c0f5b1e160db4da67f77b22b172ec2f436987b08a0fda9ad3d5f5712R1-R93) [[2]](diffhunk://#diff-bd50d1f40b98a69e9faeaf83e3db60f868dec5bc32fdb089998bacbc32257946R1-R130)
* Introduced fake implementations for testing, including a fake shell and error helpers. (`internal/test/fake/doc.go`, `internal/test/fake/errors.go`, `internal/test/fake/shell/doc.go`, `internal/test/fake/shell/shell.go`) [[1]](diffhunk://#diff-d50bc355f0d6c87a8d3c920215b25c50db6d91fae882b60ac5a09ec1c9ca67d1R1-R2) [[2]](diffhunk://#diff-656b586a1a01f14c07f256c0f4ea8e6e1b6f4912f76dd910bc45fe6e0c1f7c85R1-R8) [[3]](diffhunk://#diff-ddcd16771f8a48b0d3232a32057366322df1e4b2377076f624c7db96a8b9d47bR1-R2) [[4]](diffhunk://#diff-881fd9509f744d9c51f110620164a5789a099732202cbe9d460ea9d1310e7e5fR1-R59)

**Command package enhancements:**

* Improved the `command.Command` type by making argument slices defensive copies, and adding accessor methods (`Name`, `Args`). (`command/command.go`, `command/command_test.go`) [[1]](diffhunk://#diff-9411b7c0f7187e3e94ff7f48851c1d31db3607a56078f9aa6bb1ae80121efbcfR24-R30) [[2]](diffhunk://#diff-9411b7c0f7187e3e94ff7f48851c1d31db3607a56078f9aa6bb1ae80121efbcfR46-R60) [[3]](diffhunk://#diff-569f301ca637cccffa79c69277f15cc6a1a3e5fcaec87e2f7ac6f5f7adc51a51R89-R175)

**Build and test workflow:**

* Refined the `Makefile` to separate unit and integration tests, ensuring integration tests only run if unit tests pass. (`Makefile`)

**Documentation:**

* Added package-level documentation for `process`, `process/execution`, and related test helpers. (`process/doc.go`, `process/execution/doc.go`, `internal/test/fake/doc.go`, `internal/test/fake/shell/doc.go`) [[1]](diffhunk://#diff-ee8fa115ae1ef9f8194ed21026329adb5b7a48df5b31a9094faca66237a0b7e7R1-R2) [[2]](diffhunk://#diff-cb9fd97cb9f44d3a0ea94681f8e589a566370df38e4a90aa78d085818163f47bR1-R2) [[3]](diffhunk://#diff-d50bc355f0d6c87a8d3c920215b25c50db6d91fae882b60ac5a09ec1c9ca67d1R1-R2) [[4]](diffhunk://#diff-ddcd16771f8a48b0d3232a32057366322df1e4b2377076f624c7db96a8b9d47bR1-R2)